### PR TITLE
Added a compare method to use with local authentication

### DIFF
--- a/JFBCrypt.h
+++ b/JFBCrypt.h
@@ -44,5 +44,6 @@
 
 + (NSString *) hashPassword: (NSString *) password withSalt: (NSString *) salt;
 + (NSString *) generateSaltWithNumberOfRounds: (SInt32) numberOfRounds;
++ (BOOL)comparePassword:(NSString*)password toHash:(NSString*)hash;
 
 @end

--- a/JFBCrypt.m
+++ b/JFBCrypt.m
@@ -353,7 +353,6 @@ signed char index_64[] = {
 + (id) bCrypt {
 
 	id bCrypt = [[JFBCrypt alloc] init];
-	[bCrypt autorelease];
 	
 	return bCrypt;
 }
@@ -366,7 +365,6 @@ signed char index_64[] = {
 	JFFree(_p);
 	JFFree(_s);
 	
-	[super dealloc];
 }
 
 /*

--- a/JFBCrypt.m
+++ b/JFBCrypt.m
@@ -874,4 +874,21 @@ signed char index_64[] = {
 	return salt;
 }
 
+/*
+ * Extracts the salt from the hash and checks to see if a provided password hashes to the same value
+ *
+ * Params
+ *      password    The password to hash
+ *      hash        The computed hash containing the salt and hashed password
+ *
+ * Returns
+ *      Boolean if the password matches the hash
+ */
++ (BOOL)comparePassword:(NSString *)password toHash:(NSString *)hash
+{
+    NSString *salt = [hash substringToIndex:BCRYPT_SALT_LEN+13];
+    NSString *computedHash = [JFBCrypt hashPassword:password withSalt:salt];
+    return [hash isEqualToString:computedHash];
+}
+
 @end

--- a/JFBCrypt.podspec.json
+++ b/JFBCrypt.podspec.json
@@ -1,0 +1,24 @@
+{
+    "name": "JFBCrypt",
+    "version": "0.1.3",
+    "summary": "BCrypt in Objective C",
+    "authors": "Jason Fuerstenberg",
+    "homepage": "http://www.jayfuerstenberg.com/blog/bcrypt-in-objective-c",
+    "license": {
+        "type": "Apache",
+        "file": "LICENSE"
+    },
+    "source": {
+        "git": "https://github.com/sabymike/JFCommon.git",
+        "tag": "0.1.3"
+    },
+    "platforms": {
+        "ios": null
+    },
+    "source_files": [
+    "JFBCrypt.*",
+    "JFGC.h",
+    "JFRandom.*"
+  ],
+    "requires_arc": false
+}

--- a/JFBCrypt.podspec.json
+++ b/JFBCrypt.podspec.json
@@ -1,6 +1,6 @@
 {
     "name": "JFBCrypt",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "summary": "BCrypt in Objective C",
     "authors": "Jason Fuerstenberg",
     "homepage": "http://www.jayfuerstenberg.com/blog/bcrypt-in-objective-c",
@@ -10,7 +10,7 @@
     },
     "source": {
         "git": "https://github.com/sabymike/JFCommon.git",
-        "tag": "0.1.3"
+        "tag": "0.1.4"
     },
     "platforms": {
         "ios": null

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2014 Jason Fuerstenberg
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
I wanted to add a method to JFBCrypt so that I could check if a provided password matched the hashed version for local authorizations. I'm not thrilled with getting the salt from the hash by using a substring (line 889). If you have a cleaner solution I would be more than happy to use it.
